### PR TITLE
ci: report tests + coverage to self-hosted UniTrack

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,6 +45,16 @@ jobs:
           files: |
             **/surefire-reports/TEST-*.xml
 
+      - name: Report tests + coverage to UniTrack
+        if: always()
+        uses: alexmond/unitrack/action@v0
+        with:
+          url: ${{ vars.UNITRACK_URL }}
+          token: ${{ secrets.UNITRACK_TOKEN }}
+          junit: '**/surefire-reports/TEST-*.xml'
+          jacoco: '**/jacoco.xml'
+          soft-fail: "true"
+
       - name: Submit Dependency Snapshot
         uses: advanced-security/maven-dependency-submission-action@v5
 


### PR DESCRIPTION
Adds `alexmond/unitrack/action@v0` alongside Codecov — publishes surefire + jacoco to https://unitrack.alexmond.org. `soft-fail`. Repo var `UNITRACK_URL` + secret `UNITRACK_TOKEN` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)