### PR TITLE
ci: per-module UniTrack reporting (split-by-module)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -54,6 +54,7 @@ jobs:
           junit: '**/surefire-reports/TEST-*.xml'
           jacoco: '**/jacoco.xml'
           soft-fail: "true"
+          split-by-module: "true"
 
       - name: Submit Dependency Snapshot
         uses: advanced-security/maven-dependency-submission-action@v5


### PR DESCRIPTION
Adds `split-by-module: "true"` so each module reports as its own UniTrack coverage component, plus a rollup. 🤖 Generated with [Claude Code](https://claude.com/claude-code)