### PR TITLE
ci: builder pipeline analogs

### DIFF
--- a/.builder/pipelines/maven-release.yml
+++ b/.builder/pipelines/maven-release.yml
@@ -1,0 +1,34 @@
+name: Maven Release
+
+on: [manual]
+inputs:
+  branch:
+    type: string
+    description: Branch to release from
+    default: main
+    required: true
+  releaseVersion:
+    type: string
+    description: Release version
+    required: true
+  nextVersion:
+    type: string
+    description: Next development version (with -SNAPSHOT suffix)
+    required: true
+
+jobs:
+  release:
+    image: maven:3.9-eclipse-temurin-17
+    cache:
+      key: m2-config-json-schema
+      paths: [.m2/repository]
+    secrets: [OSSRH_USERNAME, OSSRH_PASSWORD, GPG_PRIVATE_KEY, GPG_PASSPHRASE]
+    steps:
+      - name: Checkout release branch
+        run: git clone --depth 1 --branch "$branch" https://github.com/alexmond/spring-boot-config-json-schema.git .
+      - name: Set Release Version
+        run: mvn versions:set -DnewVersion="$releaseVersion" -Pdefault --no-transfer-progress -Dmaven.repo.local=.m2/repository
+      - name: Verify Build
+        run: mvn --batch-mode verify -Pdefault --no-transfer-progress -Dmaven.repo.local=.m2/repository
+      - name: Deploy to Maven Central
+        run: mvn --batch-mode clean deploy -Prelease -Dgpg.passphrase="$GPG_PASSPHRASE" --no-transfer-progress -Dmaven.repo.local=.m2/repository

--- a/.builder/pipelines/maven.yml
+++ b/.builder/pipelines/maven.yml
@@ -1,0 +1,21 @@
+name: Java CI with Maven
+
+on: [push, manual]
+push:
+  branches: [main]
+
+jobs:
+  build:
+    image: maven:3.9-eclipse-temurin-17
+    cache:
+      key: m2-config-json-schema
+      paths: [.m2/repository]
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/spring-boot-config-json-schema.git .
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml -Pdefault --no-transfer-progress -Dmaven.repo.local=.m2/repository
+      - name: Validate generated JSON schema sample
+        run: |
+          pip install --quiet check-jsonschema
+          check-jsonschema --check-metaschema spring-boot-json-schema-sample/application.yaml

--- a/.builder/pipelines/validate-schemas.yml
+++ b/.builder/pipelines/validate-schemas.yml
@@ -1,0 +1,16 @@
+name: Validate JSON Schemas
+
+on: [push, manual]
+push:
+  branches: [main]
+
+jobs:
+  validate:
+    image: python:3-slim
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/spring-boot-config-json-schema.git .
+      - name: Install check-jsonschema
+        run: pip install --quiet check-jsonschema
+      - name: Validate sample config against its metaschema
+        run: check-jsonschema --check-metaschema spring-boot-json-schema-sample/application.yaml


### PR DESCRIPTION
Adds builder (`.builder/pipelines/*.yml`) analogs of the existing GitHub Actions workflows so the repo can be built under builder alongside Actions. Purely additive and inert — nothing here changes or disables the GitHub Actions workflows.

Mappings:
- `maven.yml` → `maven.yml`: build + package on push/manual, plus the check-jsonschema metaschema validation of the sample config. Uses a `maven:3.9-eclipse-temurin-17` image (repo has no `mvnw`) with an `.m2` cache.
- `maven_release.yml` → `maven-release.yml`: manual-trigger release with `branch` / `releaseVersion` / `nextVersion` inputs; sets version, verifies, and deploys to Maven Central. GPG/OSSRH/passphrase as secrets.
- `validateActions.yml` → `validate-schemas.yml`: runs check-jsonschema against the sample config.

Known builder gaps reflected here (not regressions):
- No git write-back, so the release pipeline can't commit/tag/push the version bumps or set the next dev version — that stays on GitHub Actions.
- No `CI_COMMIT_TAG` / GitHub Release creation analog.
- Reporting-only Actions steps (Codecov, UniTrack, publish-unit-test-result, dependency-submission, gh-release) are intentionally dropped — they have no builder analog.
- The original `validateActions.yml` lints the Actions workflow files themselves against the github-workflow schema; a builder analog has nothing to lint, so this pipeline validates the repo's own sample JSON-schema config instead.